### PR TITLE
Make it possible to write to stdout instead of to file-system

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,18 +9,25 @@ const typescript = require('./typescript')
  * const SwaggerParser = require('swagger-parser')
  */
 
-function typegen (pathToSource, pathToDestination) {
-  const source = fs.readFileSync(pathToSource, { encoding: 'utf-8' })
+function typegen (pathToSource, options) {
+ const source = fs.readFileSync(pathToSource, { encoding: 'utf-8' })
 
   const json = JSON.parse(source)
 
   const output = typescript(json)
 
-  fs.writeFileSync(pathToDestination, output)
+  if (options.output) {
+    fs.writeFileSync(options.output, output)
+    return
+  }
+
+  process.stdout.write(output)
 }
 
 program
-  .arguments('<pathToSource> <pathToDestination>')
+  .name('typegen')
+  .arguments('<pathToSource>')
+  .option('-o, --output <path>', 'write the generated output to a path')
   .action(typegen)
 
 program.parse(process.argv)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watchAll",
     "test:coverage": "jest --coverage",
-    "example": "node cli example/input.json example/output.ts"
+    "example": "node cli example/input.json -o example/output.ts"
   },
   "keywords": [],
   "author": "Matthias Margot <matthiasmargot@hotmail.com>",


### PR DESCRIPTION
Unfortunately, I can't make an argument conditionally optional in commander.

I wanted to do this:
- the 2nd argument, `pathToDestination`, is required when the flag `-l, --log` is not provided
- if `-l, --log` is provided only `pathToSource` is required and the output is simply logged to the console

Commander doesn't allow this, an argument is either optional or required, not conditionally so. I could throw a custom error but in that case, the auto-generated help message that says that `pathToDestination` is optional would not be correct, it wouldn't reflect the fact that it's optional only sometimes.

Therefore I went for an inversion of this API:
- adding an option `-o, --output` which takes the `pathToDestination`
 - making only `pathToSource` required 
- making the command log back to stdout by default

Unfortunately, this inverses the default behavior from file-system write to stdout write but we get the desired functionality and the help & documentation are consistent with the behavior.

Fixes #19